### PR TITLE
Added Search Host

### DIFF
--- a/detections/nongame_detections.json
+++ b/detections/nongame_detections.json
@@ -1,5 +1,17 @@
 [
 	{
+		"nongame_id": "38ff03203e6f40a2073968a45d38e9f8",
+		"title": "Search Host",
+		"detections": [
+			{
+				"id": "371524a1b5ba2d6946d9655378bacaf7",
+				"detect_exe": "SearchHost.exe",
+				"nongame_type": "blacklist",
+				"title": "SearchHost.exe"
+			}
+		]
+	},
+	{
 		"nongame_id": "7e8a548af7f7aa65b77dcc535123870b",
 		"title": "Smart Technology",
 		"detections": [


### PR DESCRIPTION
The Search Host runs when searching for something in Windows. It's not a game and also blocks the game detection for other games when trying to get the Window Size.
RePlays will not record the (actual) game if you start the game within 20 seconds after searching for something in Windows.

I don't really know what the ID's are for. So I MD5 hashed the title and put it as ID.